### PR TITLE
@RequestBody 사용 편의를 위한 커스텀 애노테이션 구현

### DIFF
--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/advice/UserIdInjectionAdvice.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/advice/UserIdInjectionAdvice.java
@@ -1,0 +1,73 @@
+package com.emelmujiro.secreto.auth.advice;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
+
+import com.emelmujiro.secreto.auth.annotation.InjectUserId;
+import com.emelmujiro.secreto.auth.dto.SecurityContextUser;
+import com.emelmujiro.secreto.auth.util.SecurityContextUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class UserIdInjectionAdvice implements RequestBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter methodParameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) {
+		return true;
+	}
+
+	@Override
+	public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) {
+
+		Authentication authentication = SecurityContextUtil.getAuthentication();
+		if (authentication != null && authentication.isAuthenticated()) {
+			SecurityContextUser principal = SecurityContextUtil.getPrincipal();
+			Long userId = principal.userId();
+			injectUserIdIntoAnnotatedFields(body, userId);
+		}
+		return body;
+	}
+
+	private void injectUserIdIntoAnnotatedFields(Object body, Long userId) {
+		Arrays.stream(body.getClass().getDeclaredFields())
+			.filter(this::isInjectUserIdField)
+			.forEach(field -> {
+				ReflectionUtils.makeAccessible(field);
+				ReflectionUtils.setField(field, body, userId);
+			});
+	}
+
+	private boolean isInjectUserIdField(Field field) {
+		boolean hasAnnotation = field.isAnnotationPresent(InjectUserId.class);
+		boolean hasLongType = Long.class.isAssignableFrom(field.getType()) || field.getType() == long.class;
+		return hasAnnotation && hasLongType;
+	}
+
+	@Override
+	public Object handleEmptyBody(Object body, HttpInputMessage inputMessage, MethodParameter parameter,
+		Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return body;
+	}
+
+	@Override
+	public HttpInputMessage beforeBodyRead(HttpInputMessage inputMessage, MethodParameter parameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
+		return inputMessage;
+	}
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/annotation/InjectUserId.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/annotation/InjectUserId.java
@@ -1,0 +1,11 @@
+package com.emelmujiro.secreto.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectUserId {
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/error/AuthErrorCode.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/error/AuthErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthErrorCode implements ErrorCode {
 
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "인증 헤더가 존재하지 않습니다."),
 	MISSING_BEARER_TOKEN(HttpStatus.UNAUTHORIZED, "Bearer 토큰이 존재하지 않습니다."),
 	WRONG_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "잘못된 토큰 타입입니다."),
 	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/RestAuthenticationEntryPoint.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/RestAuthenticationEntryPoint.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import com.emelmujiro.secreto.auth.error.AuthErrorCode;
+import com.emelmujiro.secreto.global.error.CommonErrorCode;
 import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 
 import jakarta.servlet.ServletException;
@@ -20,9 +20,8 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
 
-		exception.printStackTrace();
 		FilterResponseWriter.of(response)
-			.errorCode(AuthErrorCode.UNAUTHORIZED)
+			.errorCode(CommonErrorCode.INTERNAL_SERVER_ERROR)
 			.send();
 	}
 }

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
@@ -106,6 +106,9 @@ public class JwtTokenUtil {
 
 	public String resolveAuthorization(HttpServletRequest request) {
 		String authorization = request.getHeader(AUTHORIZATION);
+		if (authorization == null) {
+			throw new AuthException(AuthErrorCode.MISSING_AUTHORIZATION_HEADER);
+		}
 		if (!authorization.startsWith("Bearer ")) {
 			throw new AuthException(AuthErrorCode.MISSING_BEARER_TOKEN);
 		}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/SecurityContextUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/SecurityContextUtil.java
@@ -1,5 +1,6 @@
 package com.emelmujiro.secreto.auth.util;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.emelmujiro.secreto.auth.dto.SecurityContextUser;
@@ -7,6 +8,10 @@ import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.auth.exception.AuthException;
 
 public class SecurityContextUtil {
+
+	public static Authentication getAuthentication() {
+		return SecurityContextHolder.getContext().getAuthentication();
+	}
 
 	public static SecurityContextUser getPrincipal() {
 		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/secreto/src/main/java/com/emelmujiro/secreto/example_template/controller/TestController.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/example_template/controller/TestController.java
@@ -2,7 +2,6 @@ package com.emelmujiro.secreto.example_template.controller;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -13,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.emelmujiro.secreto.auth.annotation.InjectUserId;
 import com.emelmujiro.secreto.auth.annotation.LoginUser;
-import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.global.annotation.InjectPathVariable;
 import com.emelmujiro.secreto.global.error.CommonErrorCode;
 import com.emelmujiro.secreto.global.exception.ApiException;
@@ -52,7 +51,9 @@ public class TestController {
 	}
 
 	@PostMapping("/{one}/{two}/{three}/{four}/{five}/{six}")
-	public ResponseEntity<?> customRequestBody(@RequestBody TestDto testDto) {
+	public ResponseEntity<?> customRequestBody(@RequestBody TestDto testDto,
+		@LoginUser Long userId) {
+		log.info("userId={}", userId);
 		log.info("one={}", testDto.one);
 		log.info("two={}", testDto.twotwo);
 		log.info("three={}", testDto.three);
@@ -64,6 +65,9 @@ public class TestController {
 	}
 
 	public static class TestDto {
+
+		@InjectUserId
+		private long userId;
 
 		@InjectPathVariable(name = "one")
 		private int one;

--- a/secreto/src/main/java/com/emelmujiro/secreto/example_template/controller/TestController.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/example_template/controller/TestController.java
@@ -8,11 +8,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.emelmujiro.secreto.auth.annotation.LoginUser;
 import com.emelmujiro.secreto.auth.error.AuthErrorCode;
+import com.emelmujiro.secreto.global.annotation.InjectPathVariable;
 import com.emelmujiro.secreto.global.error.CommonErrorCode;
 import com.emelmujiro.secreto.global.exception.ApiException;
 import com.emelmujiro.secreto.global.response.ApiResponse;
@@ -48,34 +51,37 @@ public class TestController {
 		throw new ApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
 	}
 
-	@GetMapping("/refresh")
-	public ResponseEntity<?> refresh() {
-		Map<String, String> data = new HashMap<>();
-		data.put("tokenType", "refreshToken");
-
+	@PostMapping("/{one}/{two}/{three}/{four}/{five}/{six}")
+	public ResponseEntity<?> customRequestBody(@RequestBody TestDto testDto) {
+		log.info("one={}", testDto.one);
+		log.info("two={}", testDto.twotwo);
+		log.info("three={}", testDto.three);
+		log.info("four={}", testDto.four);
+		log.info("five={}", testDto.fivefive);
+		log.info("six={}", testDto.six);
 		return ApiResponse.builder()
-			.data(data)
-			.error(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
-	}
-
-	@GetMapping("/refresh-success")
-	public ResponseEntity<?> refreshSuccess() {
-		Map<String, String> data = new HashMap<>();
-		data.put("accessToken", "1234567");
-
-		return ApiResponse.builder()
-			.data(data)
 			.success();
 	}
 
-	@GetMapping("/access")
-	public ResponseEntity<?> access() {
-		Map<String, String> data = new HashMap<>();
-		data.put("tokenType", "accessToken");
+	public static class TestDto {
 
-		return ApiResponse.builder()
-			.data(data)
-			.error(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
+		@InjectPathVariable(name = "one")
+		private int one;
+
+		@InjectPathVariable(name = "two")
+		private Double twotwo;
+
+		@InjectPathVariable
+		private Long three;
+
+		@InjectPathVariable
+		private long four;
+
+		@InjectPathVariable(name = "five")
+		private String fivefive;
+
+		@InjectPathVariable
+		private float six;
 	}
 }
 

--- a/secreto/src/main/java/com/emelmujiro/secreto/global/advice/PathVariableInjectionAdvice.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/global/advice/PathVariableInjectionAdvice.java
@@ -1,0 +1,115 @@
+package com.emelmujiro.secreto.global.advice;
+
+import static org.springframework.web.servlet.HandlerMapping.*;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
+
+import com.emelmujiro.secreto.global.annotation.InjectPathVariable;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@RestControllerAdvice
+public class PathVariableInjectionAdvice implements RequestBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter methodParameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) {
+		HttpServletRequest request = getHttpServletRequest();
+		Map<String, String> pathVariables = getPathVariables(request);
+		return !pathVariables.isEmpty();
+	}
+
+	@Override
+	public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) {
+
+		HttpServletRequest request = getHttpServletRequest();
+		Map<String, String> pathVariables = getPathVariables(request);
+		injectPathVariableIntoAnnotatedFields(body, pathVariables);
+
+		return body;
+	}
+
+	private void injectPathVariableIntoAnnotatedFields(Object body, Map<String, String> pathVariables) {
+		Arrays.stream(body.getClass().getDeclaredFields())
+			.filter(field -> field.isAnnotationPresent(InjectPathVariable.class))
+			.forEach(field -> {
+				String name = resolveFieldName(field);
+				Class<?> type = field.getType();
+				Object value = getConvertedValue(pathVariables, name, type);
+
+				ReflectionUtils.makeAccessible(field);
+				ReflectionUtils.setField(field, body, value);
+			});
+	}
+
+	private Object getConvertedValue(Map<String, String> pathVariables, String name, Class<?> type) {
+		Object converted;
+		String value = pathVariables.get(name);
+		try {
+			if (Long.class.isAssignableFrom(type) || type == long.class) {
+				converted = Long.parseLong(value);
+			} else if (Integer.class.isAssignableFrom(type) || type == int.class) {
+				converted = Integer.parseInt(value);
+			} else if (Boolean.class.isAssignableFrom(type) || type == boolean.class) {
+				converted = Boolean.parseBoolean(value);
+			} else if (Double.class.isAssignableFrom(type) || type == double.class) {
+				converted = Double.parseDouble(value);
+			} else if (Float.class.isAssignableFrom(type) || type == float.class) {
+				converted = Float.parseFloat(value);
+			} else {
+				converted = pathVariables.get(name);
+			}
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException(
+				String.format("Cannot convert path variable '%s' value '%s' to type %s.",
+					name, value, type)
+			);
+		}
+		return converted;
+	}
+
+	private String resolveFieldName(Field field) {
+		String name = field.getAnnotation(InjectPathVariable.class).name();
+		return (name == null || name.isEmpty()) ? field.getName() : name;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, String> getPathVariables(HttpServletRequest httpServletRequest) {
+		return (Map<String, String>) httpServletRequest.getAttribute(URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+	}
+
+	private HttpServletRequest getHttpServletRequest() {
+		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+		if (!(requestAttributes instanceof ServletRequestAttributes)) {
+			throw new IllegalStateException("No current HTTP request available.");
+		}
+		return ((ServletRequestAttributes) requestAttributes).getRequest();
+	}
+
+	@Override
+	public Object handleEmptyBody(Object body, HttpInputMessage inputMessage, MethodParameter parameter,
+		Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return body;
+	}
+
+	@Override
+	public HttpInputMessage beforeBodyRead(HttpInputMessage inputMessage, MethodParameter parameter, Type targetType,
+		Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
+		return inputMessage;
+	}
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/global/annotation/InjectPathVariable.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/global/annotation/InjectPathVariable.java
@@ -1,0 +1,13 @@
+package com.emelmujiro.secreto.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectPathVariable {
+
+	String name() default "";
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/global/annotation/InjectPathVariable.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/global/annotation/InjectPathVariable.java
@@ -10,4 +10,5 @@ import java.lang.annotation.Target;
 public @interface InjectPathVariable {
 
 	String name() default "";
+	boolean required() default true;
 }

--- a/secreto/src/main/java/com/emelmujiro/secreto/global/config/WebMvcConfig.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/global/config/WebMvcConfig.java
@@ -7,7 +7,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.emelmujiro.secreto.auth.argumentresolver.LoginUserArgumentResolver;
-import com.emelmujiro.secreto.auth.util.JwtTokenUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,10 +14,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-	private final JwtTokenUtil jwtTokenUtil;
-
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-		resolvers.add(new LoginUserArgumentResolver(jwtTokenUtil));
+		resolvers.add(new LoginUserArgumentResolver());
 	}
 }


### PR DESCRIPTION
## ✅ DONE

- `@InjectUserId` 애노테이션 구현
- `@InjectPathVariable` 애노테이션 구현

## 🚀 RESULT

### **InjectUserId**
![image](https://github.com/user-attachments/assets/ba18af06-43bf-4384-baef-c15e60ac9ae8)


### **InjectPathVariable**
![image](https://github.com/user-attachments/assets/fb29d82c-4e44-4821-ae71-8fb07e07153f)
![image](https://github.com/user-attachments/assets/16acc292-9069-4ae5-b990-b66a6df709fd)

`/api/test/1/2/3/4/문자열/6.234` 호출 시 정상적으로 DTO 매핑
![image](https://github.com/user-attachments/assets/dd26e433-eaef-412c-b396-1c639e0432a7)

