### PR TITLE
인증 로직 개선

### DIFF
--- a/secreto/.gitignore
+++ b/secreto/.gitignore
@@ -37,3 +37,4 @@ out/
 ### VS Code ###
 .vscode/
 
+/logs/

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/config/SecurityConfig.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.emelmujiro.secreto.auth.filter.FilterExceptionHandlingFilter;
 import com.emelmujiro.secreto.auth.filter.JwtAuthenticationFilter;
 import com.emelmujiro.secreto.auth.handler.CustomAuthenticationFailureHandler;
 import com.emelmujiro.secreto.auth.handler.CustomAuthenticationSuccessHandler;
@@ -70,6 +71,7 @@ public class SecurityConfig {
 		);
 
 		http.addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(new FilterExceptionHandlingFilter(), JwtAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/controller/AuthController.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/controller/AuthController.java
@@ -1,14 +1,11 @@
 package com.emelmujiro.secreto.auth.controller;
 
-import java.util.Map;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.emelmujiro.secreto.auth.dto.AuthToken;
 import com.emelmujiro.secreto.auth.service.AuthTokenService;
 import com.emelmujiro.secreto.auth.util.JwtTokenUtil;
 import com.emelmujiro.secreto.global.response.ApiResponse;

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/controller/AuthController.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.emelmujiro.secreto.auth.dto.AuthToken;
 import com.emelmujiro.secreto.auth.service.AuthTokenService;
 import com.emelmujiro.secreto.auth.util.JwtTokenUtil;
 import com.emelmujiro.secreto.global.response.ApiResponse;
@@ -35,9 +36,8 @@ public class AuthController {
 	@GetMapping("/refresh-access-token")
 	public ResponseEntity<?> refreshAccessToken(HttpServletRequest request) {
 		String refreshToken = jwtTokenUtil.resolveAuthorization(request);
-		final String reissuedAccessToken = authTokenService.reissueAccessToken(refreshToken);
 		return ApiResponse.builder()
-			.data(Map.of("accessToken", reissuedAccessToken))
+			.data(authTokenService.reissueAuthToken(refreshToken))
 			.success();
 	}
 }

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/FilterExceptionHandlingFilter.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/FilterExceptionHandlingFilter.java
@@ -3,13 +3,10 @@ package com.emelmujiro.secreto.auth.filter;
 import static com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil.*;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.auth.exception.AuthException;
-import com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil;
 import com.emelmujiro.secreto.global.error.CommonErrorCode;
 import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/FilterExceptionHandlingFilter.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/FilterExceptionHandlingFilter.java
@@ -1,0 +1,42 @@
+package com.emelmujiro.secreto.auth.filter;
+
+import static com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.emelmujiro.secreto.auth.error.AuthErrorCode;
+import com.emelmujiro.secreto.auth.exception.AuthException;
+import com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil;
+import com.emelmujiro.secreto.global.error.CommonErrorCode;
+import com.emelmujiro.secreto.global.response.FilterResponseWriter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FilterExceptionHandlingFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request, HttpServletResponse response, FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (AuthException e) {
+			FilterResponseWriter.of(response)
+				.data(getAuthExceptionHandlingData(e))
+				.errorCode(e.getErrorCode())
+				.send();
+		} catch (Exception e) {
+			FilterResponseWriter.of(response)
+				.errorCode(CommonErrorCode.INTERNAL_SERVER_ERROR)
+				.send();
+		}
+	}
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/JwtAuthenticationFilter.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.emelmujiro.secreto.auth.dto.SecurityContextUser;
 import com.emelmujiro.secreto.auth.error.AuthErrorCode;
+import com.emelmujiro.secreto.auth.exception.AuthException;
 import com.emelmujiro.secreto.auth.util.JwtTokenUtil;
 import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 import com.emelmujiro.secreto.user.entity.User;
@@ -48,9 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		User findUser = userRepository.findActiveById(userId).orElse(null);
 
 		if (findUser == null) {
-			FilterResponseWriter.of(response)
-				.errorCode(AuthErrorCode.TOKEN_USER_MISSING).send();
-			return;
+			throw new AuthException(AuthErrorCode.TOKEN_USER_MISSING);
 		}
 
 		SecurityContextUser contextUser = SecurityContextUser.of(findUser);

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/JwtAuthenticationFilter.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/filter/JwtAuthenticationFilter.java
@@ -18,7 +18,6 @@ import com.emelmujiro.secreto.auth.dto.SecurityContextUser;
 import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.auth.exception.AuthException;
 import com.emelmujiro.secreto.auth.util.JwtTokenUtil;
-import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 import com.emelmujiro.secreto.user.entity.User;
 import com.emelmujiro.secreto.user.repository.UserRepository;
 

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/AuthExceptionHandler.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/AuthExceptionHandler.java
@@ -2,13 +2,10 @@ package com.emelmujiro.secreto.auth.handler;
 
 import static com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil.*;
 
-import java.util.Map;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.auth.exception.AuthException;
 import com.emelmujiro.secreto.global.response.ApiResponse;
 

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/AuthExceptionHandler.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/AuthExceptionHandler.java
@@ -1,17 +1,18 @@
 package com.emelmujiro.secreto.auth.handler;
 
+import static com.emelmujiro.secreto.auth.util.ExceptionHandlingUtil.*;
+
 import java.util.Map;
 
-import com.emelmujiro.secreto.auth.exception.AuthException;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.emelmujiro.secreto.auth.error.AuthErrorCode;
-import com.emelmujiro.secreto.global.exception.ApiException;
+import com.emelmujiro.secreto.auth.exception.AuthException;
 import com.emelmujiro.secreto.global.response.ApiResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,16 +22,12 @@ public class AuthExceptionHandler {
 	@ExceptionHandler(AuthException.class)
 	public ResponseEntity<ApiResponse<?>> handleCustomException(AuthException e, HttpServletRequest request) {
 		log.error("========== [AUTH EXCEPTION] ==========\n" +
-						"RequestURI: {}\nMessage: {}\n",
-				request.getRequestURI(),
-				e.getErrorCode().getMessage(), e);
+				"RequestURI: {}\nMessage: {}\n",
+			request.getRequestURI(),
+			e.getErrorCode().getMessage(), e);
 
-		Map<String, Object> data = null;
-		if (e.getErrorCode() == AuthErrorCode.REFRESH_TOKEN_EXPIRED) {
-			data = Map.of("tokenType", "refreshToken");
-		} else if (e.getErrorCode() == AuthErrorCode.ACCESS_TOKEN_EXPIRED) {
-			data = Map.of("tokenType", "accessToken");
-		}
-		return ApiResponse.builder().data(data).error(e.getErrorCode());
+		return ApiResponse.builder()
+			.data(getAuthExceptionHandlingData(e))
+			.error(e.getErrorCode());
 	}
 }

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/CustomAuthenticationFailureHandler.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/CustomAuthenticationFailureHandler.java
@@ -22,7 +22,6 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
 
-		exception.printStackTrace();
 		FilterResponseWriter.of(response)
 			.errorCode(AuthErrorCode.UNAUTHORIZED)
 			.send();

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/RestAuthenticationEntryPoint.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/handler/RestAuthenticationEntryPoint.java
@@ -12,15 +12,20 @@ import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
+		log.error("========== [AUTH ENTRY POINT] ==========\n" +
+				"RequestURI: {}\nMessage: {}\n",
+			request.getRequestURI(),
+			exception.getMessage(), exception);
 
-		exception.printStackTrace();
 		FilterResponseWriter.of(response)
 			.errorCode(CommonErrorCode.INTERNAL_SERVER_ERROR)
 			.send();

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/service/AuthTokenService.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/service/AuthTokenService.java
@@ -10,7 +10,7 @@ public interface AuthTokenService {
 
 	void saveRefreshToken(Long userId, String refreshToken);
 
-	String reissueAccessToken(String refreshToken);
+	AuthToken reissueAuthToken(String refreshToken);
 
 	void deleteRefreshToken(Long userId);
 

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/service/impl/AuthTokenServiceImpl.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/service/impl/AuthTokenServiceImpl.java
@@ -99,12 +99,13 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 		refreshTokenRedisTemplate.delete(String.valueOf(userId));
 	}
 
-	public String reissueAccessToken(String refreshToken) {
+	public AuthToken reissueAuthToken(String refreshToken) {
 		if (!jwtTokenUtil.isRefreshToken(refreshToken)) {
 			throw new AuthException(AuthErrorCode.WRONG_TOKEN_TYPE);
 		}
 		Long userId = jwtTokenUtil.getUserId(refreshToken);
 		String storedRefreshToken = sanitizeString(refreshTokenRedisTemplate.opsForValue().get(String.valueOf(userId)));
+
 
 		if (!refreshToken.equals(storedRefreshToken)) {
 			throw new AuthException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
@@ -113,7 +114,13 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 		User user = userRepository.findActiveById(userId)
 			.orElseThrow(() -> new AuthException(AuthErrorCode.TOKEN_USER_MISSING));
 
-		return jwtTokenUtil.generateAccessToken(user);
+		String reissuedAccessToken = jwtTokenUtil.generateAccessToken(user);
+		String reissuedRefreshToken = jwtTokenUtil.generateRefreshToken(user);
+
+		deleteRefreshToken(userId);
+		saveRefreshToken(userId, reissuedRefreshToken);
+
+		return AuthToken.ofBearer(reissuedRefreshToken, reissuedAccessToken);
 	}
 
 	private String sanitizeString(String value) {

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/ExceptionHandlingUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/ExceptionHandlingUtil.java
@@ -1,0 +1,19 @@
+package com.emelmujiro.secreto.auth.util;
+
+import java.util.Map;
+
+import com.emelmujiro.secreto.auth.error.AuthErrorCode;
+import com.emelmujiro.secreto.auth.exception.AuthException;
+
+public class ExceptionHandlingUtil {
+
+	public static Map<String, Object> getAuthExceptionHandlingData(AuthException e) {
+		Map<String, Object> data = null;
+		if (e.getErrorCode() == AuthErrorCode.REFRESH_TOKEN_EXPIRED) {
+			data = Map.of("tokenType", "refreshToken");
+		} else if (e.getErrorCode() == AuthErrorCode.ACCESS_TOKEN_EXPIRED) {
+			data = Map.of("tokenType", "accessToken");
+		}
+		return data;
+	}
+}

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 import com.emelmujiro.secreto.auth.dto.AuthToken;
 import com.emelmujiro.secreto.auth.error.AuthErrorCode;
 import com.emelmujiro.secreto.auth.exception.AuthException;
-import com.emelmujiro.secreto.global.response.FilterResponseWriter;
 import com.emelmujiro.secreto.user.entity.User;
 
 import io.jsonwebtoken.Claims;

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
@@ -82,6 +82,15 @@ public class JwtTokenUtil {
 		return buildToken(userId, claims, refreshTokenExpirationSeconds * 1000L);
 	}
 
+	public String generateRefreshToken(User user) {
+		final Map<String, Object> claims = new HashMap<>(Map.of(
+			"username", user.getUsername(),
+			"provider", user.getOAuthProvider(),
+			"role", user.getRole()
+		));
+		return generateRefreshToken(user.getId(), claims);
+	}
+
 	private String generateAccessToken(Long userId, Map<String, Object> claims) {
 		claims.put("tokenType", TOKEN_TYPE_ACCESS);
 		return buildToken(userId, claims, accessTokenExpirationSeconds * 1000L);

--- a/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
+++ b/secreto/src/main/java/com/emelmujiro/secreto/auth/util/JwtTokenUtil.java
@@ -134,21 +134,13 @@ public class JwtTokenUtil {
 	}
 
 	public String validateAccessToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		String authorization = null;
-		try {
-			authorization = resolveAuthorization(request);
-		} catch (AuthException e) {
-			FilterResponseWriter.of(response)
-				.errorCode(e.getErrorCode()).send();
-		}
+		String authorization = resolveAuthorization(request);
 
 		if (!verifyToken(authorization)) {
-			FilterResponseWriter.of(response)
-				.data(Map.of("tokenType", "accessToken"))
-				.errorCode(AuthErrorCode.ACCESS_TOKEN_EXPIRED).send();
+			throw new AuthException(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
 		}
 		if (!isAccessToken(authorization)) {
-			FilterResponseWriter.of(response).errorCode(AuthErrorCode.WRONG_TOKEN_TYPE).send();
+			throw new AuthException(AuthErrorCode.WRONG_TOKEN_TYPE);
 		}
 		return authorization;
 	}


### PR DESCRIPTION
## ✅ DONE

- 인증 과정 에러 발생 시 500에러 반환하는 문제 개선
- 리프레시 토큰 1회용으로 변경

## 🚀 RESULT

- [GET] /auth/refresh-access-token
    - 응답 값으로 AccessToken, RefreshToken을 모두 재발급
![image](https://github.com/user-attachments/assets/19e8a80c-d2b2-447d-afa7-4d305048e660)
